### PR TITLE
Validated eslintrc file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
         "node": true
     },
     "extends": "eslint:recommended",
-    "parser": "./node_modules/babel-eslint",
+    "parser": "babel-eslint",
     "parserOptions": {
         "ecmaVersion": 12
     },
@@ -29,7 +29,9 @@
         ],
         "no-unused-vars": [
             "error",
-            "after-used"
+            {
+                "args": "after-used"
+            }
         ]
     }
 }


### PR DESCRIPTION
According to the [Eslint documentation](https://eslint.org/docs/rules/no-unused-vars#disallow-unused-variables-no-unused-vars), `no-unused-vars` options should be written in Object ( `{}` ) with key `args`.

The parser from eslintrc.json will be resolved from the node_modules automatically. You must give the name of the parser only.

Signed-off-by: Moulik Aggarwal <moulik@deepsource.io>